### PR TITLE
feat: improve time precision by using local double values

### DIFF
--- a/MapWizard.BeatmapParser/Editor.cs
+++ b/MapWizard.BeatmapParser/Editor.cs
@@ -6,8 +6,14 @@ namespace MapWizard.BeatmapParser;
 /// <summary> Represents a editor section</summary>
 public class Editor
 {
+    private List<double>? _bookmarkMilliseconds;
+
     /// <summary> Time in milliseconds of bookmarks. </summary>
-    public List<TimeSpan>? Bookmarks { get; set; }
+    public List<TimeSpan>? Bookmarks
+    {
+        get => _bookmarkMilliseconds?.Select(TimeSpan.FromMilliseconds).ToList();
+        set => _bookmarkMilliseconds = value?.Select(x => x.TotalMilliseconds).ToList();
+    }
 
     /// <summary> Distance snap multiplier. </summary>
     public double DistanceSpacing { get; set; }
@@ -29,9 +35,9 @@ public class Editor
     /// <param name="beatDivisor"></param>
     /// <param name="gridSize"></param>
     /// <param name="timelineZoom"></param>
-    private Editor(List<TimeSpan>? bookmarks, double distanceSpacing, int beatDivisor, int gridSize, double? timelineZoom)
+    private Editor(List<double>? bookmarks, double distanceSpacing, int beatDivisor, int gridSize, double? timelineZoom)
     {
-        Bookmarks = bookmarks;
+        _bookmarkMilliseconds = bookmarks;
         DistanceSpacing = distanceSpacing;
         BeatDivisor = beatDivisor;
         GridSize = gridSize;
@@ -68,7 +74,7 @@ public class Editor
 
             return new Editor(
                 bookmarks: bookmarks?.Split(',').Where(x => !string.IsNullOrEmpty(x)).Select(
-                    x => TimeSpan.FromMilliseconds(double.Parse(x, CultureInfo.InvariantCulture))).ToList(),
+                    x => double.Parse(x, CultureInfo.InvariantCulture)).ToList(),
                 distanceSpacing: editor.TryGetValue("DistanceSpacing", out string? value) ? double.Parse(value, CultureInfo.InvariantCulture) : 1.0,
                 beatDivisor: editor.TryGetValue("BeatDivisor", out var beatDivisorStr) ? int.Parse(beatDivisorStr) : 4,
                 gridSize: editor.TryGetValue("GridSize", out var gridSizeStr) ? int.Parse(gridSizeStr) : 4,
@@ -106,9 +112,9 @@ public class Editor
                 continue;
             }
 
-            if (prop.GetValue(this) is List<TimeSpan> bookmarks)
+            if (prop.Name == nameof(Bookmarks) && _bookmarkMilliseconds is not null)
             {
-                builder.AppendLine($"{prop.Name}: {string.Join(',', bookmarks.Select(x => Helper.FormatTime(x.TotalMilliseconds)))}");
+                builder.AppendLine($"{prop.Name}: {string.Join(',', _bookmarkMilliseconds.Select(Helper.FormatTime))}");
                 continue;
             }
 

--- a/MapWizard.BeatmapParser/Events/Animation.cs
+++ b/MapWizard.BeatmapParser/Events/Animation.cs
@@ -9,6 +9,8 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Animation : Sprite
 {
+    private double _frameDelayMilliseconds;
+
     /// <summary>
     /// Gets or sets the number of frames in the animation.
     /// Determines the total count of sequential images that compose the animation.
@@ -19,7 +21,11 @@ public class Animation : Sprite
     /// Gets or sets the delay between consecutive frames in the animation.
     /// Specifies the time duration for which each frame is displayed.
     /// </summary>
-    public TimeSpan FrameDelay { get; set; }
+    public TimeSpan FrameDelay
+    {
+        get => TimeSpan.FromMilliseconds(_frameDelayMilliseconds);
+        set => _frameDelayMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the type of loop behavior for the animation.
@@ -53,13 +59,13 @@ public class Animation : Sprite
         string filePath,
         Vector2 position,
         uint frameCount,
-        TimeSpan frameDelay,
+        double frameDelayMilliseconds,
         LoopType looptype,
         List<ICommand>? commands = null
     ) : base(layer, origin, filePath, position, commands)
     {
         FrameCount = frameCount;
-        FrameDelay = frameDelay;
+        _frameDelayMilliseconds = frameDelayMilliseconds;
         Looptype = looptype;
     }
 
@@ -78,7 +84,7 @@ public class Animation : Sprite
     private Animation() : base()
     {
         FrameCount = 0;
-        FrameDelay = TimeSpan.FromMilliseconds(0);
+        _frameDelayMilliseconds = 0;
         Looptype = LoopType.LoopForever;
     }
 
@@ -94,9 +100,9 @@ public class Animation : Sprite
     /// <returns>A string that represents the serialized form of the animation, including its properties and commands.</returns>
     public new string Encode()
     {
-        if (Commands.Count == 0) return $"{EventType.Animation},{(int)Layer},{(int)Origin},{FilePath},{Position.X.ToString(CultureInfo.InvariantCulture)},{Position.Y.ToString(CultureInfo.InvariantCulture)},{FrameCount},{FrameDelay},{Looptype}";
+        if (Commands.Count == 0) return $"{EventType.Animation},{(int)Layer},{(int)Origin},{FilePath},{Position.X.ToString(CultureInfo.InvariantCulture)},{Position.Y.ToString(CultureInfo.InvariantCulture)},{FrameCount},{_frameDelayMilliseconds.ToString(CultureInfo.InvariantCulture)},{Looptype}";
         StringBuilder builder = new();
-        builder.AppendLine($"{EventType.Animation},{(int)Layer},{(int)Origin},{FilePath},{Position.X.ToString(CultureInfo.InvariantCulture)},{Position.Y.ToString(CultureInfo.InvariantCulture)},{FrameCount},{FrameDelay},{Looptype}");
+        builder.AppendLine($"{EventType.Animation},{(int)Layer},{(int)Origin},{FilePath},{Position.X.ToString(CultureInfo.InvariantCulture)},{Position.Y.ToString(CultureInfo.InvariantCulture)},{FrameCount},{_frameDelayMilliseconds.ToString(CultureInfo.InvariantCulture)},{Looptype}");
         foreach (var command in Commands[..^1])
         {
             builder.AppendLine(command is IHasCommands ? string.Join(Environment.NewLine, command.Encode().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => " " + line)) : " " + command.Encode());
@@ -127,7 +133,7 @@ public class Animation : Sprite
             filePath: lineSplit[3],
             position: new Vector2(float.Parse(lineSplit[4], CultureInfo.InvariantCulture), float.Parse(lineSplit[5], CultureInfo.InvariantCulture)),
             frameCount: uint.Parse(lineSplit[6]),
-            frameDelay: TimeSpan.FromMilliseconds(double.Parse(lineSplit[7], CultureInfo.InvariantCulture)),
+            frameDelayMilliseconds: double.Parse(lineSplit[7], CultureInfo.InvariantCulture),
             looptype: lineSplit.Length > 8 ? (LoopType)Enum.Parse(typeof(LoopType), lineSplit[8] ?? throw new Exception("Invalid looptype")) : LoopType.LoopForever
         );
 

--- a/MapWizard.BeatmapParser/Events/Background.cs
+++ b/MapWizard.BeatmapParser/Events/Background.cs
@@ -11,6 +11,8 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Background : IEvent, IHasCommands
 {
+    private double _startMilliseconds;
+
     /// <summary>
     /// Specifies the type of the event. This property determines the category of the event,
     /// such as background, video, sprite, or other supported event types within the beatmap.
@@ -20,7 +22,11 @@ public class Background : IEvent, IHasCommands
     /// <summary>
     /// The start time of the background event. It doesn't really is used for anything.
     /// </summary>
-    public TimeSpan StartTime { get; set; }
+    public TimeSpan StartTime
+    {
+        get => TimeSpan.FromMilliseconds(_startMilliseconds);
+        set => _startMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the file name of the background image.
@@ -52,7 +58,7 @@ public class Background : IEvent, IHasCommands
     /// </summary>
     public Background(string filename, Vector2? offset = null)
     {
-        StartTime = TimeSpan.FromMilliseconds(0);
+        _startMilliseconds = 0;
         Filename = filename;
         Offset = offset;
         Commands = [];
@@ -62,9 +68,9 @@ public class Background : IEvent, IHasCommands
     /// Represents a background event in a beatmap.
     /// This is the event used to set the beatmap background image.
     /// </summary>
-    private Background(TimeSpan time, string filename, Vector2? offset = null)
+    private Background(double timeMilliseconds, string filename, Vector2? offset = null)
     {
-        StartTime = time;
+        _startMilliseconds = timeMilliseconds;
         Filename = filename;
         Offset = offset;
         Commands = [];
@@ -80,7 +86,7 @@ public class Background : IEvent, IHasCommands
     {
         StringBuilder sb = new();
 
-        sb.Append($"{(int)Type},{StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},{Filename}");
+        sb.Append($"{(int)Type},{_startMilliseconds.ToString(CultureInfo.InvariantCulture)},{Filename}");
 
         if (Offset != null) sb.Append($",{Offset?.X.ToString(CultureInfo.InvariantCulture)},{Offset?.Y.ToString(CultureInfo.InvariantCulture)}");
 
@@ -112,10 +118,11 @@ public class Background : IEvent, IHasCommands
         try
         {
             var args = line.Trim().Split(',');
+            var start = double.Parse(args[1], CultureInfo.InvariantCulture);
             return new Background
             (
+                timeMilliseconds: start,
                 filename: args[2],
-                time: TimeSpan.FromMilliseconds(float.Parse(args[1], CultureInfo.InvariantCulture)),
                 offset: args.Length >= 4 ? new Vector2(float.Parse(args[3], CultureInfo.InvariantCulture), float.Parse(args[4], CultureInfo.InvariantCulture)) : null
             );
         }

--- a/MapWizard.BeatmapParser/Events/Break.cs
+++ b/MapWizard.BeatmapParser/Events/Break.cs
@@ -8,6 +8,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Break : IEvent
 {
+    private double _startMilliseconds;
+    private double _endMilliseconds;
+
     /// <summary>
     /// Represents the <see cref="EventType"/> of the event, indicating the category or nature of the beatmap event.
     /// </summary>
@@ -16,20 +19,28 @@ public class Break : IEvent
     /// <summary>
     /// The start time of the break period.
     /// </summary>
-    public TimeSpan StartTime { get; set;}
+    public TimeSpan StartTime
+    {
+        get => TimeSpan.FromMilliseconds(_startMilliseconds);
+        set => _startMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// The end time of the break period.
     /// </summary>
-    public TimeSpan EndTime { get; set; }
+    public TimeSpan EndTime
+    {
+        get => TimeSpan.FromMilliseconds(_endMilliseconds);
+        set => _endMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents a break event in a beatmap. A break defines a period during which gameplay is paused.
     /// </summary>
-    private Break(TimeSpan startTime, TimeSpan endTime)
+    private Break(double startMilliseconds, double endMilliseconds)
     {
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
     }
 
     /// <summary>
@@ -38,7 +49,7 @@ public class Break : IEvent
     private Break()
     {
         StartTime = TimeSpan.FromMilliseconds(0);
-        EndTime = TimeSpan.FromMilliseconds(0);
+        _endMilliseconds = 0;
     }
 
     /// <summary>
@@ -52,9 +63,9 @@ public class Break : IEvent
         StringBuilder sb = new StringBuilder();
         sb.Append($"{(int)EventType.Break}");
         sb.Append(',');
-        sb.Append(StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+        sb.Append(_startMilliseconds.ToString(CultureInfo.InvariantCulture));
         sb.Append(',');
-        sb.Append(EndTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+        sb.Append(_endMilliseconds.ToString(CultureInfo.InvariantCulture));
         return sb.ToString();
     }
 
@@ -70,11 +81,9 @@ public class Break : IEvent
         try
         {
             var args = line.Trim().Split(',');
-            return new Break
-            (
-                startTime: TimeSpan.FromMilliseconds(int.Parse(args[1])),
-                endTime: TimeSpan.FromMilliseconds(int.Parse(args[2]))
-            );
+            var start = double.Parse(args[1], CultureInfo.InvariantCulture);
+            var end = double.Parse(args[2], CultureInfo.InvariantCulture);
+            return new Break(startMilliseconds: start, endMilliseconds: end);
         }
         catch (Exception ex)
         {

--- a/MapWizard.BeatmapParser/Events/Commands/Colour.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Colour.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Colour : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Specifies the type of a command within the beatmap, identifying its category
     /// or the specific kind of transformation it performs.
@@ -26,13 +29,21 @@ public class Colour : ICommand
     /// Represents the start time of the colour transformation command within the beatmap,
     /// indicating the point in time at which the transformation begins.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the optional end time of the colour transformation command, indicating
     /// when the transformation is completed within the beatmap timeline.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the initial color value used in a color transformation command,
@@ -51,15 +62,15 @@ public class Colour : ICommand
     /// </summary>
     private Colour(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         Color? startColour,
         Color? endColour
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartColour = startColour;
         EndColour = endColour;
     }
@@ -76,8 +87,8 @@ public class Colour : ICommand
         var commandSplit = line.Trim().Split(',');
 
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         Color? startColour = commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? Helper.ParseColorFromUnknownString(string.Join(',', commandSplit[4], commandSplit[5], commandSplit[6])) : null;
         Color? endColour = commandSplit.Length > 7 && !string.IsNullOrEmpty(commandSplit[7]) ? Helper.ParseColorFromUnknownString(string.Join(',', commandSplit[7], commandSplit[8], commandSplit[9])) : null;
 
@@ -91,7 +102,7 @@ public class Colour : ICommand
     public string Encode()
     {
         StringBuilder sb = new();
-        sb.Append($"C,{(int)Easing},{StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty},{EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty}");
+        sb.Append($"C,{(int)Easing},{_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty},{_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty}");
 
         if (StartColour != null) sb.Append($",{StartColour?.R},{StartColour?.G},{StartColour?.B}");
         else sb.Append(",,,");

--- a/MapWizard.BeatmapParser/Events/Commands/Fade.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Fade.cs
@@ -9,6 +9,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Fade : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Gets the specific type of the command, represented by the <see cref="CommandType"/> enumeration.
     /// This property identifies the nature of the command, such as Fade, Move, Scale, or other supported
@@ -29,13 +32,21 @@ public class Fade : ICommand
     /// Gets or sets the start time of the fade command in the beatmap.
     /// This property defines the timestamp at which the fade effect begins.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the fade command. This property represents the time
     /// at which the fade effect concludes, measured in a <see cref="TimeSpan"/>.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the starting opacity value for the fade effect.
@@ -57,15 +68,15 @@ public class Fade : ICommand
     /// </summary>
     private Fade(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         double? startOpacity,
         double? endOpacity
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartOpacity = startOpacity;
         EndOpacity = endOpacity;
     }
@@ -85,8 +96,8 @@ public class Fade : ICommand
         return new Fade
         (
             easing: (Easing)Enum.Parse(typeof(Easing), commandSplit[1]),
-            startTime: commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null,
-            endTime: commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null,
+            startMilliseconds: commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null,
+            endMilliseconds: commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null,
             startOpacity: commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? double.Parse(commandSplit[4], CultureInfo.InvariantCulture) : null,
             endOpacity: commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[5]) ? double.Parse(commandSplit[5], CultureInfo.InvariantCulture) : null
         );
@@ -106,9 +117,9 @@ public class Fade : ICommand
         sb.Append("F,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
         sb.Append(StartOpacity?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
 

--- a/MapWizard.BeatmapParser/Events/Commands/Loop.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Loop.cs
@@ -9,6 +9,8 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Loop : ICommand, IHasCommands
 {
+    private double _startMilliseconds;
+
     /// <summary>
     /// Specifies the command type for the loop instance.
     /// This property is used to identify the loop as a specific command type
@@ -22,7 +24,11 @@ public class Loop : ICommand, IHasCommands
     /// This property defines the initial point in time where the loop begins execution.
     /// It is expressed as a TimeSpan value.
     /// </summary>
-    public TimeSpan StartTime { get; set; }
+    public TimeSpan StartTime
+    {
+        get => TimeSpan.FromMilliseconds(_startMilliseconds);
+        set => _startMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the number of repetitions for the Loop instance.
@@ -43,9 +49,9 @@ public class Loop : ICommand, IHasCommands
     /// starting from a specified time. The loop has a start time, a number of iterations,
     /// and a list of commands to execute during each iteration.
     /// </summary>
-    private Loop(TimeSpan startTime, uint count, List<ICommand> commands)
+    private Loop(double startMilliseconds, uint count, List<ICommand> commands)
     {
-        StartTime = startTime;
+        _startMilliseconds = startMilliseconds;
         Count = count;
         Commands = commands;
     }
@@ -63,9 +69,11 @@ public class Loop : ICommand, IHasCommands
 
         var commandSplit = line.Trim().Split(',');
 
+        var start = double.Parse(commandSplit[1], CultureInfo.InvariantCulture);
+
         return new Loop
         (
-            startTime: TimeSpan.FromMilliseconds(int.Parse(commandSplit[1])),
+            startMilliseconds: start,
             count: uint.Parse(commandSplit[2]),
             commands: []
         );
@@ -80,10 +88,10 @@ public class Loop : ICommand, IHasCommands
     /// in the osu! file format.</returns>
     public string Encode()
     {
-        if (Commands.Count == 0) return $"L,{StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},{Count}";
+        if (Commands.Count == 0) return $"L,{_startMilliseconds.ToString(CultureInfo.InvariantCulture)},{Count}";
 
         StringBuilder builder = new();
-        builder.AppendLine($"L,{StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},{Count}");
+        builder.AppendLine($"L,{_startMilliseconds.ToString(CultureInfo.InvariantCulture)},{Count}");
 
         foreach (var command in Commands[..^1])
         {
@@ -94,7 +102,6 @@ public class Loop : ICommand, IHasCommands
         return builder.ToString();
     }
 }
-
 
 
 

--- a/MapWizard.BeatmapParser/Events/Commands/Move.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Move.cs
@@ -12,6 +12,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Move : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Defines the type of the command associated with the <see cref="Move"/> class.
     /// This property is initialized to the value <see cref="CommandType.Move"/>,
@@ -30,14 +33,22 @@ public class Move : ICommand
     /// Specifies the start time of the command event represented as a nullable <see cref="TimeSpan"/>.
     /// This property denotes when the move command should begin execution within the beatmap timeline.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the move command.
     /// This property indicates the timestamp at which the motion or transformation
     /// reaches its final position, marking the conclusion of the specified time interval.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Specifies the starting position of the move command in a 2D coordinate system.
@@ -56,15 +67,15 @@ public class Move : ICommand
     /// </summary>
     private Move(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         Vector2? startPosition,
         Vector2? endPosition
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartPosition = startPosition;
         EndPosition = endPosition;
     }
@@ -82,8 +93,8 @@ public class Move : ICommand
         var commandSplit = line.Trim().Split(',');
 
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         Vector2? startPosition = commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[4]) && !string.IsNullOrEmpty(commandSplit[5]) ?
             new Vector2(float.Parse(commandSplit[4], CultureInfo.InvariantCulture), float.Parse(commandSplit[5], CultureInfo.InvariantCulture)) : null;
         Vector2? endPosition = commandSplit.Length > 7 && !string.IsNullOrEmpty(commandSplit[6]) && !string.IsNullOrEmpty(commandSplit[7]) ?
@@ -106,9 +117,9 @@ public class Move : ICommand
         sb.Append("M,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         if (StartPosition != null)
         {
             sb.Append(',');

--- a/MapWizard.BeatmapParser/Events/Commands/MoveX.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/MoveX.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class MoveX : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Gets the type of command associated with this instance.
     /// This property specifies a unique identifier for the particular command within a set of defined command types.
@@ -28,14 +31,22 @@ public class MoveX : ICommand
     /// This property represents the time at which the movement begins,
     /// expressed as a nullable <see cref="TimeSpan"/> for flexibility in defining a specific time point.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the ending time of the horizontal movement command.
     /// This property defines the point in time when the movement concludes, typically measured from the start
     /// of the beatmap timeline. A null value indicates that the ending time is not explicitly defined.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the starting X-coordinate for the horizontal movement.
@@ -57,15 +68,15 @@ public class MoveX : ICommand
     /// </summary>
     private MoveX(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         double? startX,
         double? endX
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartX = startX;
         EndX = endX;
     }
@@ -88,8 +99,8 @@ public class MoveX : ICommand
 
         var commandSplit = line.Trim().Split(',');
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         double? startX = commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? double.Parse(commandSplit[4], CultureInfo.InvariantCulture) : null;
         double? endX = commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[5]) ? double.Parse(commandSplit[5], CultureInfo.InvariantCulture) : null;
 
@@ -109,9 +120,9 @@ public class MoveX : ICommand
         sb.Append("MX,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
         sb.Append(StartX?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
 

--- a/MapWizard.BeatmapParser/Events/Commands/MoveY.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/MoveY.cs
@@ -8,6 +8,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class MoveY : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Gets the type of the command, which is MoveY.
     /// </summary>
@@ -21,12 +24,20 @@ public class MoveY : ICommand
     /// <summary>
     /// Gets or sets the start time of the movement.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the movement.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the starting Y-coordinate of the movement.
@@ -48,15 +59,15 @@ public class MoveY : ICommand
     /// <param name="endY">The ending Y-coordinate of the movement.</param>
     private MoveY(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         double? startY,
         double? endY
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartY = startY;
         EndY = endY;
     }
@@ -72,8 +83,8 @@ public class MoveY : ICommand
 
         var commandSplit = line.Trim().Split(',');
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         double? startY = commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? double.Parse(commandSplit[4], CultureInfo.InvariantCulture) : null;
         double? endY = commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[5]) ? double.Parse(commandSplit[5], CultureInfo.InvariantCulture) : null;
 
@@ -90,9 +101,9 @@ public class MoveY : ICommand
         sb.Append("MY,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
         sb.Append(StartY?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
 

--- a/MapWizard.BeatmapParser/Events/Commands/Parameter.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Parameter.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Parameter : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Represents the specific type of command associated with the parameter.
     /// This property is initialized to the default value of <see cref="CommandType.Parameter"/>.
@@ -27,14 +30,22 @@ public class Parameter : ICommand
     /// Represents the starting time of the parameter command in a beatmap.
     /// This property is optional and specifies the time at which the parameter effect begins.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the end time of a command in the beatmap, indicating when the effect
     /// or parameter transition associated with the command ends.
     /// This property is nullable, as not all commands require an explicit end time.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the name of the parameter being applied.
@@ -48,14 +59,14 @@ public class Parameter : ICommand
     /// </summary>
     private Parameter(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         ParameterName parameterName
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         ParameterName = parameterName;
     }
 
@@ -69,8 +80,8 @@ public class Parameter : ICommand
         var commandSplit = line.Trim().Split(',');
 
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         ParameterName parameterName = commandSplit[4].Last() switch
         {
             'A' => ParameterName.AdditiveBlending,
@@ -94,9 +105,9 @@ public class Parameter : ICommand
         sb.Append("P,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
         sb.Append((char)(int)ParameterName);
         return sb.ToString();

--- a/MapWizard.BeatmapParser/Events/Commands/Rotate.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Rotate.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Rotate : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Gets the type of the command represented by this property.
     /// </summary>
@@ -53,7 +56,11 @@ public class Rotate : ICommand
     /// A <see cref="TimeSpan"/> representing the time at which the rotation command
     /// starts, or null if no start time is defined.
     /// </value>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the rotation command.
@@ -68,7 +75,11 @@ public class Rotate : ICommand
     /// A <see cref="TimeSpan?"/> value that indicates the time, in milliseconds, at
     /// which the rotation command finishes. Returns null if no end time is specified.
     /// </value>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the initial rotation value for a rotate command.
@@ -104,15 +115,15 @@ public class Rotate : ICommand
     /// </summary>
     private Rotate(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         double? startRotate,
         double? endRotate
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartRotate = startRotate;
         EndRotate = endRotate;
     }
@@ -130,8 +141,8 @@ public class Rotate : ICommand
         return new Rotate
         (
             easing: (Easing)Enum.Parse(typeof(Easing), commandSplit[1]),
-            startTime: commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null,
-            endTime: commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null,
+            startMilliseconds: commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null,
+            endMilliseconds: commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null,
             startRotate: commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? double.Parse(commandSplit[4], CultureInfo.InvariantCulture) : null,
             endRotate: commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[5]) ? double.Parse(commandSplit[5], CultureInfo.InvariantCulture) : null
         );
@@ -149,9 +160,9 @@ public class Rotate : ICommand
         sb.Append("R,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         sb.Append(',');
         sb.Append(StartRotate?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         if (EndRotate == null) return sb.ToString();

--- a/MapWizard.BeatmapParser/Events/Commands/Scale.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Scale.cs
@@ -9,6 +9,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Scale : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Gets the type of the command represented by this instance.
     /// This property is used to specify the behavior or action
@@ -28,13 +31,21 @@ public class Scale : ICommand
     /// This property defines the point in time at which the scale adjustment begins,
     /// represented as a nullable <see cref="TimeSpan"/>.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the scale transformation command.
     /// This property defines the time at which the scaling operation finishes.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the starting scale value of the transformation.
@@ -55,15 +66,15 @@ public class Scale : ICommand
     /// </summary>
     private Scale(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         double? startScale,
         double? endScale
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartScale = startScale;
         EndScale = endScale;
     }
@@ -84,8 +95,8 @@ public class Scale : ICommand
 
 
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         double? startScale = commandSplit.Length > 4 && !string.IsNullOrEmpty(commandSplit[4]) ? double.Parse(commandSplit[4], CultureInfo.InvariantCulture) : null;
         double? endScale = commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[5]) ? double.Parse(commandSplit[5], CultureInfo.InvariantCulture) : null;
 
@@ -107,9 +118,9 @@ public class Scale : ICommand
         sb.Append("S,");
         sb.Append((int)Easing);
         sb.Append(',');
-        sb.Append(StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "");
+        sb.Append(_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? "");
         sb.Append(',');
-        sb.Append(EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "");
+        sb.Append(_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? "");
         sb.Append(',');
         sb.Append(StartScale?.ToString(CultureInfo.InvariantCulture) ?? "");
 

--- a/MapWizard.BeatmapParser/Events/Commands/Trigger.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/Trigger.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Trigger : ICommand, IHasCommands
 {
+    private double _startMilliseconds;
+    private double _endMilliseconds;
+
     /// <summary>
     /// Gets the type of the command, which corresponds to the predefined
     /// command types in the <see cref="CommandType"/> enum. This property
@@ -30,13 +33,21 @@ public class Trigger : ICommand, IHasCommands
     /// represented as a <see cref="TimeSpan"/>. This property defines the exact
     /// time at which the actions defined by the trigger will begin.
     /// </summary>
-    public TimeSpan StartTime { get; set; }
+    public TimeSpan StartTime
+    {
+        get => TimeSpan.FromMilliseconds(_startMilliseconds);
+        set => _startMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the end time of the trigger, which specifies the time at which
     /// the associated actions or commands cease within a beatmap.
     /// </summary>
-    public TimeSpan EndTime { get; set; }
+    public TimeSpan EndTime
+    {
+        get => TimeSpan.FromMilliseconds(_endMilliseconds);
+        set => _endMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the collection of commands associated with this object.
@@ -49,11 +60,11 @@ public class Trigger : ICommand, IHasCommands
     /// Represents a Trigger command that defines an action or group of actions
     /// occurring within a specific time frame in a beatmap.
     /// </summary>
-    private Trigger(string triggerType, TimeSpan startTime, TimeSpan endTime, List<ICommand> commands)
+    private Trigger(string triggerType, double startMilliseconds, double endMilliseconds, List<ICommand> commands)
     {
         TriggerType = triggerType;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         Commands = commands;
     }
 
@@ -69,11 +80,14 @@ public class Trigger : ICommand, IHasCommands
 
         var commandSplit = line.Trim().Split(',');
 
+        var start = double.Parse(commandSplit[2], CultureInfo.InvariantCulture);
+        var end = double.Parse(commandSplit[3], CultureInfo.InvariantCulture);
+
         return new Trigger
         (
             triggerType: commandSplit[1],
-            startTime: TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])),
-            endTime: TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])),
+            startMilliseconds: start,
+            endMilliseconds: end,
             commands: []
         );
     }
@@ -88,10 +102,10 @@ public class Trigger : ICommand, IHasCommands
     /// </returns>
     public string Encode()
     {
-        if (Commands.Count == 0) return $"T,{TriggerType},{StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},{EndTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)}";
+        if (Commands.Count == 0) return $"T,{TriggerType},{_startMilliseconds.ToString(CultureInfo.InvariantCulture)},{_endMilliseconds.ToString(CultureInfo.InvariantCulture)}";
 
         StringBuilder builder = new();
-        builder.AppendLine($"T,{TriggerType},{StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},{EndTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)}");
+        builder.AppendLine($"T,{TriggerType},{_startMilliseconds.ToString(CultureInfo.InvariantCulture)},{_endMilliseconds.ToString(CultureInfo.InvariantCulture)}");
 
         foreach (var command in Commands[..^1])
         {

--- a/MapWizard.BeatmapParser/Events/Commands/VectorScale.cs
+++ b/MapWizard.BeatmapParser/Events/Commands/VectorScale.cs
@@ -10,6 +10,9 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class VectorScale : ICommand
 {
+    private double? _startMilliseconds;
+    private double? _endMilliseconds;
+
     /// <summary>
     /// Represents the specific command type for the current instance of ICommand.
     /// Defines the behavior and purpose of the command, which in this case is set to VectorScale.
@@ -26,13 +29,21 @@ public class VectorScale : ICommand
     /// Defines the starting time of the vector scaling command in a beatmap.
     /// This property represents the moment when the scaling transition begins, measured as a nullable TimeSpan.
     /// </summary>
-    public TimeSpan? StartTime { get; set; }
+    public TimeSpan? StartTime
+    {
+        get => _startMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_startMilliseconds.Value) : null;
+        set => _startMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Represents the optional end time of the vector scaling command.
     /// Determines the time at which the scaling operation concludes.
     /// </summary>
-    public TimeSpan? EndTime { get; set; }
+    public TimeSpan? EndTime
+    {
+        get => _endMilliseconds.HasValue ? TimeSpan.FromMilliseconds(_endMilliseconds.Value) : null;
+        set => _endMilliseconds = value?.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Defines the starting vector scale for a scaling operation.
@@ -52,15 +63,15 @@ public class VectorScale : ICommand
     /// </summary>
     private VectorScale(
         Easing easing,
-        TimeSpan? startTime,
-        TimeSpan? endTime,
+        double? startMilliseconds,
+        double? endMilliseconds,
         Vector2? startVectorScale,
         Vector2? endVectorScale
     )
     {
         Easing = easing;
-        StartTime = startTime;
-        EndTime = endTime;
+        _startMilliseconds = startMilliseconds;
+        _endMilliseconds = endMilliseconds;
         StartVectorScale = startVectorScale;
         EndVectorScale = endVectorScale;
     }
@@ -77,8 +88,8 @@ public class VectorScale : ICommand
         var commandSplit = line.Trim().Split(',');
 
         Easing easing = commandSplit.Length > 1 ? (Easing)Enum.Parse(typeof(Easing), commandSplit[1]) : Easing.Linear;
-        TimeSpan? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[2])) : null;
-        TimeSpan? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? TimeSpan.FromMilliseconds(int.Parse(commandSplit[3])) : null;
+        double? startTime = commandSplit.Length > 2 && !string.IsNullOrEmpty(commandSplit[2]) ? double.Parse(commandSplit[2], CultureInfo.InvariantCulture) : null;
+        double? endTime = commandSplit.Length > 3 && !string.IsNullOrEmpty(commandSplit[3]) ? double.Parse(commandSplit[3], CultureInfo.InvariantCulture) : null;
         Vector2? startVectorScale = commandSplit.Length > 5 && !string.IsNullOrEmpty(commandSplit[4]) && !string.IsNullOrEmpty(commandSplit[5]) ?
             new Vector2(float.Parse(commandSplit[4], CultureInfo.InvariantCulture), float.Parse(commandSplit[5], CultureInfo.InvariantCulture)) : null;
         Vector2? endVectorScale = commandSplit.Length > 7 && !string.IsNullOrEmpty(commandSplit[6]) && !string.IsNullOrEmpty(commandSplit[7]) ?
@@ -96,7 +107,7 @@ public class VectorScale : ICommand
     public string Encode()
     {
         StringBuilder sb = new();
-        sb.Append($"V,{(int)Easing},{StartTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty},{EndTime?.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) ?? string.Empty}");
+        sb.Append($"V,{(int)Easing},{_startMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty},{_endMilliseconds?.ToString(CultureInfo.InvariantCulture) ?? string.Empty}");
 
         if (StartVectorScale != null) sb.Append($",{StartVectorScale?.X.ToString(CultureInfo.InvariantCulture)},{StartVectorScale?.Y.ToString(CultureInfo.InvariantCulture)}");
         else sb.Append(",,");

--- a/MapWizard.BeatmapParser/Events/Sample.cs
+++ b/MapWizard.BeatmapParser/Events/Sample.cs
@@ -8,6 +8,8 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class Sample : IEvent
 {
+    private double _startMilliseconds;
+
     /// <summary>
     /// Gets the type of the event, represented as an <see cref="EventType"/>.
     /// </summary>
@@ -17,7 +19,11 @@ public class Sample : IEvent
     /// Gets or sets the start time of the sample event,
     /// represented as a <see cref="TimeSpan"/>.
     /// </summary>
-    public TimeSpan StartTime { get; set; }
+    public TimeSpan StartTime
+    {
+        get => TimeSpan.FromMilliseconds(_startMilliseconds);
+        set => _startMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the layer in which the sample event is positioned. Defaults to Background.
@@ -38,19 +44,19 @@ public class Sample : IEvent
     
     private Sample()
     {
-        StartTime = TimeSpan.FromMilliseconds(0);
+        _startMilliseconds = 0;
         Layer = Layer.Background;
         FilePath = string.Empty;
         Volume = 100;
     }
-    
+
     private Sample(
-        TimeSpan startTime,
+        double startMilliseconds,
         Layer layer,
         string filePath,
         int volume)
     {
-        StartTime = startTime;
+        _startMilliseconds = startMilliseconds;
         Layer = layer;
         FilePath = filePath;
         Volume = volume;
@@ -65,7 +71,7 @@ public class Sample : IEvent
         StringBuilder sb = new StringBuilder();
         sb.Append($"{(int)EventType.Sample}");
         sb.Append(',');
-        sb.Append(StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+        sb.Append(_startMilliseconds.ToString(CultureInfo.InvariantCulture));
         sb.Append(',');
         sb.Append(Layer);
         sb.Append(',');
@@ -87,9 +93,10 @@ public class Sample : IEvent
         try
         {
             var args = line.Trim().Split(',');
+            var start = double.Parse(args[1], CultureInfo.InvariantCulture);
             return new Sample
             (
-                startTime: TimeSpan.FromMilliseconds(int.Parse(args[1])),
+                startMilliseconds: start,
                 layer: (Layer)Enum.Parse(typeof(Layer), args[2]),
                 filePath: args[3],
                 volume: args.Length > 4 ? int.Parse(args[4]) : 100

--- a/MapWizard.BeatmapParser/Helpers/Math.cs
+++ b/MapWizard.BeatmapParser/Helpers/Math.cs
@@ -37,8 +37,20 @@ public partial class Helper
     public static TimeSpan ClampTimeSpan(double value)
     {
         if (TimeSpan.MaxValue.TotalMilliseconds < value) return TimeSpan.MaxValue;
-        
+
         return TimeSpan.MinValue.TotalMilliseconds > value ? TimeSpan.MinValue : TimeSpan.FromMilliseconds(value);
+    }
+
+    /// <summary>
+    /// Clamps a millisecond value to the valid <see cref="TimeSpan"/> range, preserving double precision.
+    /// </summary>
+    /// <param name="value">Value in milliseconds.</param>
+    /// <returns>The original value clamped to <see cref="TimeSpan.MinValue"/> and <see cref="TimeSpan.MaxValue"/> bounds.</returns>
+    public static double ClampMilliseconds(double value)
+    {
+        if (value > TimeSpan.MaxValue.TotalMilliseconds) return TimeSpan.MaxValue.TotalMilliseconds;
+        if (value < TimeSpan.MinValue.TotalMilliseconds) return TimeSpan.MinValue.TotalMilliseconds;
+        return value;
     }
 
 

--- a/MapWizard.BeatmapParser/HitObjects.cs
+++ b/MapWizard.BeatmapParser/HitObjects.cs
@@ -114,9 +114,9 @@ public class HitObjects
         {
             switch (obj)
             {
-                case Circle circle when Math.Abs(circle.Time.TotalMilliseconds - time) <= leniency:
+                case Circle circle when Math.Abs(circle.TimeMilliseconds - time) <= leniency:
                     return circle;
-                case Slider slider when Math.Abs(slider.Time.TotalMilliseconds - time) <= leniency || Math.Abs(slider.EndTime.TotalMilliseconds - time) <= leniency:
+                case Slider slider when Math.Abs(slider.TimeMilliseconds - time) <= leniency || Math.Abs(slider.EndTime.TotalMilliseconds - time) <= leniency:
                     return slider;
                 case Slider slider:
                     {
@@ -130,7 +130,7 @@ public class HitObjects
 
                         break;
                     }
-                case Spinner spinner when Math.Abs(spinner.End.TotalMilliseconds - time) <= leniency:
+                case Spinner spinner when Math.Abs(spinner.EndMilliseconds - time) <= leniency:
                     return spinner;
             }
         }

--- a/MapWizard.BeatmapParser/HitObjects/Circle.cs
+++ b/MapWizard.BeatmapParser/HitObjects/Circle.cs
@@ -31,7 +31,7 @@ public class Circle : HitObject
     /// Initializes a new instance of the Circle class.
     /// </summary>
     /// <param name="baseObject">The base hit object to copy properties from.</param>
-    private Circle(IHitObject baseObject) : base(baseObject.Coordinates, baseObject.Time, baseObject.Type, baseObject.HitSounds, baseObject.NewCombo, baseObject.ComboOffset)
+    private Circle(HitObject baseObject) : base(baseObject)
     {
     }
 
@@ -42,6 +42,7 @@ public class Circle : HitObject
     /// <returns></returns>
     public new static Circle Decode(List<string> splitData)
     {
-        return new Circle(HitObject.Decode(splitData));
+        var baseObject = HitObject.Decode(splitData);
+        return new Circle(baseObject);
     }
 }

--- a/MapWizard.BeatmapParser/HitObjects/ManiaHold.cs
+++ b/MapWizard.BeatmapParser/HitObjects/ManiaHold.cs
@@ -35,7 +35,7 @@ public class ManiaHold : HitObject
     /// Initializes a new instance of the <see cref="ManiaHold"/> class.
     /// </summary>
     /// <param name="baseObject"></param>
-    public ManiaHold(HitObject baseObject) : base(baseObject.Coordinates, baseObject.Time, baseObject.Type, baseObject.HitSounds, baseObject.NewCombo, baseObject.ComboOffset)
+    public ManiaHold(HitObject baseObject) : base(baseObject)
     {
     }
 }

--- a/MapWizard.BeatmapParser/HitObjects/Slider.cs
+++ b/MapWizard.BeatmapParser/HitObjects/Slider.cs
@@ -102,7 +102,7 @@ public class Slider : HitObject
     /// Initializes a new instance of the <see cref="Slider"/> class.
     /// </summary>
     /// <param name="baseObject">The base hit object to copy properties from.</param>
-    private Slider(IHitObject baseObject) : base(baseObject.Coordinates, baseObject.Time, baseObject.Type, baseObject.HitSounds, baseObject.NewCombo, baseObject.ComboOffset)
+    private Slider(HitObject baseObject) : base(baseObject)
     {
         LegacyCurveType = null;
         ControlPoints = [];
@@ -247,9 +247,9 @@ public class Slider : HitObject
                 Slides = uint.Parse(split[6] == "NaN" ? "1" : split[6]),
                 Length = double.Parse(split[7] == "NaN" ? "0" : split[7], CultureInfo.InvariantCulture),
                 EndTime = Helper.CalculateEndTime(
-                    sliderMultiplier: difficulty.SliderMultiplier * timingPoints.GetSliderVelocityAt(double.Parse(split[2], CultureInfo.InvariantCulture)),
-                    beatLength: timingPoints.GetUninheritedTimingPointAt(double.Parse(split[2], CultureInfo.InvariantCulture))?.BeatLength ?? 500,
-                    startTime: TimeSpan.FromMilliseconds(double.Parse(split[2], CultureInfo.InvariantCulture)),
+                    sliderMultiplier: difficulty.SliderMultiplier * timingPoints.GetSliderVelocityAt(baseObject.TimeMilliseconds),
+                    beatLength: timingPoints.GetUninheritedTimingPointAt(baseObject.TimeMilliseconds)?.BeatLength ?? 500,
+                    startTime: baseObject.Time,
                     pixelLength: double.Parse(split[7] == "NaN" ? "0" : split[7], CultureInfo.InvariantCulture),
                     repeats: int.Parse(split[6] == "NaN" ? "1" : split[6])
                 ),
@@ -276,7 +276,7 @@ public class Slider : HitObject
         StringBuilder builder = new();
         
         builder.Append($"{Helper.FormatCoord(Coordinates.X)},{Helper.FormatCoord(Coordinates.Y)},");
-        builder.Append($"{Helper.FormatTime(Time.TotalMilliseconds)},");
+        builder.Append($"{Helper.FormatTime(TimeMilliseconds)},");
 
         int type = (int)Type | (NewCombo ? 1 << 2 : 0) | ((int)ComboOffset << 4);
         builder.Append($"{type},");

--- a/MapWizard.BeatmapParser/TimingPoints/InheritedTimingPoint.cs
+++ b/MapWizard.BeatmapParser/TimingPoints/InheritedTimingPoint.cs
@@ -33,6 +33,17 @@ public class InheritedTimingPoint : TimingPoint
         SliderVelocity = sliderVelocity;
     }
 
+    public InheritedTimingPoint(
+        double timeMilliseconds,
+        SampleSet sampleSet,
+        uint sampleIndex,
+        uint volume,
+        List<Effect> effects,
+        double sliderVelocity) : base(timeMilliseconds, sampleSet, sampleIndex, volume, effects)
+    {
+        SliderVelocity = sliderVelocity;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InheritedTimingPoint"/> class.
     /// </summary>
@@ -48,6 +59,6 @@ public class InheritedTimingPoint : TimingPoint
     public string Encode(TimingPoints section)
     {
         var sv = 100 / -SliderVelocity;
-        return $"{Helper.FormatTime(Time.TotalMilliseconds)},{ (Helper.FormatVersion == 128 ? sv : Math.Round(sv, 13)).ToString(CultureInfo.InvariantCulture)},{section.GetUninheritedTimingPointAt(Time.TotalMilliseconds)?.TimeSignature ?? 4},{(int)SampleSet},{SampleIndex},{Volume},{0},{Helper.EncodeEffects(Effects)}";
+        return $"{Helper.FormatTime(TimeMilliseconds)},{ (Helper.FormatVersion == 128 ? sv : Math.Round(sv, 13)).ToString(CultureInfo.InvariantCulture)},{section.GetUninheritedTimingPointAt(TimeMilliseconds)?.TimeSignature ?? 4},{(int)SampleSet},{SampleIndex},{Volume},{0},{Helper.EncodeEffects(Effects)}";
     }
 }

--- a/MapWizard.BeatmapParser/TimingPoints/TimingPoint.cs
+++ b/MapWizard.BeatmapParser/TimingPoints/TimingPoint.cs
@@ -5,10 +5,16 @@ namespace MapWizard.BeatmapParser;
 /// </summary>
 public class TimingPoint
 {
+    private double _timeMilliseconds;
+
     /// <summary>
     /// Gets or sets the start time timing point of the beatmap.
     /// </summary>
-    public TimeSpan Time { get; set; }
+    public TimeSpan Time
+    {
+        get => TimeSpan.FromMilliseconds(_timeMilliseconds);
+        set => _timeMilliseconds = value.TotalMilliseconds;
+    }
 
     /// <summary>
     /// Gets or sets the sample set of objects in the beatmap.
@@ -38,13 +44,18 @@ public class TimingPoint
     /// <param name="sampleIndex"></param>
     /// <param name="volume"></param>
     /// <param name="effects"></param>
-    public TimingPoint(TimeSpan time, SampleSet sampleSet, uint sampleIndex, uint volume, List<Effect> effects)
+    protected TimingPoint(double timeMilliseconds, SampleSet sampleSet, uint sampleIndex, uint volume, List<Effect> effects)
     {
-        Time = time;
+        _timeMilliseconds = timeMilliseconds;
         SampleSet = sampleSet;
         SampleIndex = sampleIndex;
         Volume = volume;
         Effects = effects;
+    }
+
+    public TimingPoint(TimeSpan time, SampleSet sampleSet, uint sampleIndex, uint volume, List<Effect> effects)
+        : this(time.TotalMilliseconds, sampleSet, sampleIndex, volume, effects)
+    {
     }
 
     /// <summary>
@@ -52,10 +63,16 @@ public class TimingPoint
     /// </summary>
     public TimingPoint()
     {
-        Time = TimeSpan.Zero;
+        _timeMilliseconds = 0;
         SampleSet = SampleSet.Default;
         SampleIndex = 0;
         Volume = 0;
         Effects = [];
+    }
+
+    internal double TimeMilliseconds
+    {
+        get => _timeMilliseconds;
+        set => _timeMilliseconds = value;
     }
 }

--- a/MapWizard.BeatmapParser/TimingPoints/UninheritedTimingPoint.cs
+++ b/MapWizard.BeatmapParser/TimingPoints/UninheritedTimingPoint.cs
@@ -40,6 +40,19 @@ public class UninheritedTimingPoint : TimingPoint
         TimeSignature = timeSignature;
     }
 
+    public UninheritedTimingPoint(
+        double timeMilliseconds,
+        SampleSet sampleSet,
+        uint sampleIndex,
+        uint volume,
+        List<Effect> effects,
+        double beatLength,
+        int timeSignature) : base(timeMilliseconds, sampleSet, sampleIndex, volume, effects)
+    {
+        BeatLength = beatLength;
+        TimeSignature = timeSignature;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="UninheritedTimingPoint"/> class.
     /// </summary>
@@ -55,7 +68,7 @@ public class UninheritedTimingPoint : TimingPoint
     /// <returns></returns>
     public string Encode()
     {
-        return $"{Helper.FormatTime(Time.TotalMilliseconds)},{BeatLength.ToString("G", CultureInfo.InvariantCulture)},{TimeSignature},{(int)SampleSet},{SampleIndex},{Volume},{1},{Helper.EncodeEffects(Effects)}";
+        return $"{Helper.FormatTime(TimeMilliseconds)},{BeatLength.ToString("G", CultureInfo.InvariantCulture)},{TimeSignature},{(int)SampleSet},{SampleIndex},{Volume},{1},{Helper.EncodeEffects(Effects)}";
     }
 
     /// <summary>


### PR DESCRIPTION
This actually turns the TimeSpans into interfaces to update/get the values, this is useful so we don't lose precision when exporting to format v128

Also there's some better encoding that was broken since the last update

closes #6