### PR TITLE
fix: workaround sukiui wayland window resize

### DIFF
--- a/MapWizard.Desktop/Controls/MapWizardWindow.cs
+++ b/MapWizard.Desktop/Controls/MapWizardWindow.cs
@@ -1,0 +1,66 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using SukiUI.Controls;
+
+namespace MapWizard.Desktop.Controls;
+
+/// <summary>
+/// Applies the SukiUI Wayland resize fix while retaining SukiWindow's template and behavior.
+/// This can be removed once the fix from SukiUI PR #621 is included in the referenced package.
+/// </summary>
+public class MapWizardWindow : SukiWindow
+{
+    public MapWizardWindow()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            AddHandler(
+                PointerPressedEvent,
+                OnResizeGripPointerPressed,
+                RoutingStrategies.Tunnel);
+        }
+    }
+
+    private void OnResizeGripPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!CanResize || WindowState != WindowState.Normal)
+            return;
+
+        if (e.Source is not Border { Tag: string edge })
+            return;
+
+        if (!TryGetWindowEdge(edge, out var windowEdge))
+            return;
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY")) &&
+            WindowDecorations == WindowDecorations.None)
+        {
+            WindowDecorations = WindowDecorations.BorderOnly;
+        }
+
+        // SukiUI 7.0.1 uses VisualRoot here, which is null on Wayland. The
+        // SukiWindow instance is already the Window, so invoke the drag on it directly.
+        BeginResizeDrag(windowEdge, e);
+        e.Handled = true;
+    }
+
+    private static bool TryGetWindowEdge(string edge, out WindowEdge windowEdge)
+    {
+        windowEdge = edge switch
+        {
+            "North" => WindowEdge.North,
+            "South" => WindowEdge.South,
+            "West" => WindowEdge.West,
+            "East" => WindowEdge.East,
+            "NW" => WindowEdge.NorthWest,
+            "NE" => WindowEdge.NorthEast,
+            "SW" => WindowEdge.SouthWest,
+            "SE" => WindowEdge.SouthEast,
+            _ => default
+        };
+
+        return edge is "North" or "South" or "West" or "East" or "NW" or "NE" or "SW" or "SE";
+    }
+}

--- a/MapWizard.Desktop/Views/MainWindow.axaml
+++ b/MapWizard.Desktop/Views/MainWindow.axaml
@@ -1,4 +1,4 @@
-<suki:SukiWindow
+<controls:MapWizardWindow
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vm="using:MapWizard.Desktop.ViewModels"
@@ -11,6 +11,7 @@
     xmlns:comboColourStudio="clr-namespace:MapWizard.Desktop.Views.ComboColourStudio"
     xmlns:mapCleaner="clr-namespace:MapWizard.Desktop.Views.MapCleaner"
     xmlns:settings="clr-namespace:MapWizard.Desktop.Views.Settings"
+    xmlns:controls="clr-namespace:MapWizard.Desktop.Controls"
     x:Class="MapWizard.Desktop.Views.MainWindow"
     x:DataType="vm:MainWindowViewModel"
     WindowDecorations="BorderOnly"
@@ -340,4 +341,4 @@
         </TransitioningContentControl>
         </Grid>
     </VisualLayerManager>
-</suki:SukiWindow>
+</controls:MapWizardWindow>

--- a/MapWizard.Desktop/Views/MainWindow.axaml.cs
+++ b/MapWizard.Desktop/Views/MainWindow.axaml.cs
@@ -1,12 +1,12 @@
 using Avalonia.Interactivity;
+using MapWizard.Desktop.Controls;
 using MapWizard.Desktop.Services;
 using MapWizard.Desktop.ViewModels;
-using SukiUI.Controls;
 using SukiUI.Enums;
 
 namespace MapWizard.Desktop.Views
 {
-public partial class MainWindow : SukiWindow
+public partial class MainWindow : MapWizardWindow
     {
         private readonly IThemeService _themeService;
 


### PR DESCRIPTION
This creates a new MapWizardWindow that inherits SukiWindow in order to workarround a wayland windowning bug.

based loosely on the upstream fix at https://github.com/kikipoulet/SukiUI/pull/621

this is meant to be a temporary fix